### PR TITLE
feat: add initial defi dashboard skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,31 @@
-- 👋 Hi, I’m @Joonsense
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+## DeFi Dashboard
 
-Python, ML, Finance, Marketing, 
+This repository contains a minimal Next.js + Radix UI dashboard that displays
+stablecoin statistics from the [DeFi Llama](https://stablecoins.llama.fi) API.
+The interface uses Radix UI primitives and Tailwind CSS for styling.
+
+### Development
+
+1. Install dependencies with `npm install` (requires network access).
+2. Run the development server with `npm run dev`.
+3. Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+### Features
+
+- Fetches the top stablecoins and displays them in a table.
+- Uses Radix UI `Tabs` component for layout.
+- Tailwind CSS styling with dark-mode ready theme provider.
+
+---
+
+👋 Hi, I’m @Joonsense
+👀 I’m interested in ...
+🌱 I’m currently learning ...
+💞️ I’m looking to collaborate on ...
+📫 How to reach me ...
+Python, ML, Finance, Marketing,
 Blockchain, Trend, Idea, Business
-
 <!---
 Joonsense/Joonsense is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
---->
+-->

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "defi-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@radix-ui/react-tabs": "1.0.3",
+    "@radix-ui/themes": "3.0.0",
+    "axios": "1.6.2",
+    "socket.io-client": "4.7.2"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "@types/node": "20.9.0",
+    "@types/react": "18.2.43",
+    "@types/react-dom": "18.2.17",
+    "eslint": "8.54.0",
+    "eslint-config-next": "14.2.3",
+    "tailwindcss": "3.3.3",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import { Theme } from '@radix-ui/themes';
+
+export const metadata = {
+  title: 'DeFi Dashboard',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Theme>{children}</Theme>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import * as Tabs from '@radix-ui/react-tabs';
+import StablecoinTable from '../components/StablecoinTable';
+
+export default function Page() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">DeFi Dashboard</h1>
+      <Tabs.Root defaultValue="stablecoins">
+        <Tabs.List className="flex space-x-4 mb-4">
+          <Tabs.Trigger value="stablecoins">Stablecoins</Tabs.Trigger>
+          <Tabs.Trigger value="defi">DeFi Protocols</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="stablecoins">
+          <StablecoinTable />
+        </Tabs.Content>
+        <Tabs.Content value="defi">
+          <div>Coming soon...</div>
+        </Tabs.Content>
+      </Tabs.Root>
+    </main>
+  );
+}

--- a/src/components/StablecoinTable.tsx
+++ b/src/components/StablecoinTable.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface Stablecoin {
+  name: string;
+  symbol: string;
+  price: number;
+  circulating: number;
+}
+
+export default function StablecoinTable() {
+  const [data, setData] = useState<Stablecoin[]>([]);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await axios.get('https://stablecoins.llama.fi/stablecoins');
+        const list = res.data?.peggedAssets?.slice(0, 10) ?? [];
+        const mapped = list.map((item: any) => ({
+          name: item.name,
+          symbol: item.symbol,
+          price: item.price,
+          circulating: item.circulating
+        }));
+        setData(mapped);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return (
+    <table className="min-w-full text-left">
+      <thead>
+        <tr>
+          <th className="p-2">Name</th>
+          <th className="p-2">Price</th>
+          <th className="p-2">Circulating</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((coin) => (
+          <tr key={coin.symbol}>
+            <td className="p-2">{coin.name} ({coin.symbol})</td>
+            <td className="p-2">{coin.price.toFixed(2)}</td>
+            <td className="p-2">{coin.circulating.toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export async function fetchStablecoins() {
+  const res = await axios.get('https://stablecoins.llama.fi/stablecoins');
+  return res.data;
+}

--- a/src/pages/api/hello.ts
+++ b/src/pages/api/hello.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.status(200).json({ message: 'ok' });
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js + Radix UI project for DeFi dashboard
- include stablecoin table fetching data from DeFi Llama
- configure Tailwind and basic API route

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24b9062288330ae0a603ca5f612fc