### PR TITLE
Refine dark UI hierarchy on perp and builder pages

### DIFF
--- a/src/app/api/perp/route.ts
+++ b/src/app/api/perp/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { hlToPerp } from "../../../server/hl/adapter";
+import { fetchHLMarkets } from "../../../server/hl/fetch";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  try {
+    const rawMarkets = await fetchHLMarkets();
+    const markets = rawMarkets.map(hlToPerp);
+
+    return NextResponse.json({ ok: true, markets });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+// 수동 테스트: curl -X GET http://localhost:3000/api/perp

--- a/src/app/builder/page.tsx
+++ b/src/app/builder/page.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+
+import builderData from "@/data/builder.json";
+import { formatCompact } from "@/utils/format/number";
+
+type BuilderTeam = {
+  code: string;
+  owner: string;
+  members: number;
+  volume24h: number;
+  estRewards: number;
+};
+
+const rawTeams = builderData as BuilderTeam[];
+
+export default function BuilderPage() {
+  const teams = [...rawTeams].sort((a, b) => b.volume24h - a.volume24h);
+  const hasTeams = teams.length > 0;
+
+  return (
+    <div className="min-h-screen bg-slate-950 px-6 py-12 text-slate-100">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <div className="flex flex-col gap-3">
+          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-slate-800 bg-slate-900/80 px-3 py-1 text-xs uppercase tracking-wide text-slate-400">
+            모의 데이터 • 실데이터 연동 예정
+          </span>
+          <div className="flex flex-col gap-2">
+            <h1 className="text-3xl font-semibold text-white">Builder Rankings</h1>
+            <p className="text-sm text-slate-400">
+              Hyperliquid 빌더 레퍼럴 팀의 24시간 거래 실적을 기준으로 정렬했습니다.
+            </p>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/80">
+          {hasTeams ? (
+            <>
+              <div className="grid grid-cols-[50px,1fr,1fr,1fr,1fr,120px] items-center gap-4 border-b border-slate-700/70 bg-gradient-to-r from-slate-900 via-slate-900/70 to-slate-900/40 px-6 py-4 text-xs font-semibold uppercase tracking-wide text-slate-300">
+                <span>#</span>
+                <span>Code</span>
+                <span>Owner</span>
+                <span>Members</span>
+                <span>24h Vol</span>
+                <span className="text-right">Join</span>
+              </div>
+              <div className="divide-y divide-slate-800 text-sm">
+                {teams.map((team, index) => (
+                  <div
+                    key={team.code}
+                    className="grid grid-cols-[50px,1fr,1fr,1fr,1fr,120px] items-center gap-4 px-6 py-4 text-slate-300 transition hover:bg-slate-900"
+                  >
+                    <span className="font-semibold text-slate-200">{index + 1}</span>
+                    <span className="font-medium text-slate-100">{team.code}</span>
+                    <span>{team.owner}</span>
+                    <span>{Number.isFinite(team.members) ? team.members.toLocaleString() : "—"}</span>
+                    <span className="font-medium text-slate-100">
+                      ${formatCompact(team.volume24h)}
+                    </span>
+                    <span className="flex justify-end">
+                      <Link
+                        href={`https://app.hyperliquid.xyz/?ref=${team.code}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center rounded-full border border-slate-700 bg-slate-800 px-4 py-2 text-xs font-semibold text-slate-200 transition hover:border-slate-500 hover:bg-slate-700 hover:text-white"
+                      >
+                        Join
+                      </Link>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="flex h-40 items-center justify-center text-sm text-slate-400">
+              No builder codes
+            </div>
+          )}
+        </div>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/80 p-6 text-sm text-slate-300">
+          <h2 className="text-base font-semibold text-slate-100">운영 아이디어</h2>
+          <p className="mt-3 leading-relaxed">
+            커뮤니티 참여 이벤트와 일일 미션을 통해 신규 유입을 늘리고, 상위 빌더에 대한
+            스포트라이트 콘텐츠를 제작해 브랜드 신뢰도를 강화할 계획입니다.
+          </p>
+          <p className="mt-2 leading-relaxed">
+            {/* TODO: 실데이터 연동 시 자동화된 리워드 계산 및 공시 기능 추가 */}
+            장기적으로는 실시간 거래 데이터를 연동하여 보상 누적치를 자동으로 추적하고
+            공시하는 대시보드를 제공할 예정입니다.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <main className="min-h-screen bg-neutral-950 text-neutral-100 flex flex-col items-center justify-center px-6 py-12">
+      <div className="max-w-md w-full space-y-6 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          deLeaderboard (HL only)
+        </h1>
+        <nav>
+          <ul className="space-y-3 text-sm">
+            <li>
+              <Link
+                href="/perp"
+                className="inline-flex w-full items-center justify-between rounded-xl border border-neutral-800 bg-neutral-900 px-4 py-3 transition hover:border-neutral-600 hover:bg-neutral-800"
+              >
+                <span className="font-medium">Perp Markets</span>
+                <span className="text-xs text-neutral-400">/perp</span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/builder"
+                className="inline-flex w-full items-center justify-between rounded-xl border border-neutral-800 bg-neutral-900 px-4 py-3 transition hover:border-neutral-600 hover:bg-neutral-800"
+              >
+                <span className="font-medium">Builder Leaderboard</span>
+                <span className="text-xs text-neutral-400">/builder</span>
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </main>
+  );
+}

--- a/src/app/perp/page.tsx
+++ b/src/app/perp/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PerpMarket } from "@/types/market";
+import { formatCompact, formatPct, formatPrice } from "@/utils/format/number";
+
+type ViewMode = "card" | "list";
+
+type PerpResponse = {
+  ok: boolean;
+  markets?: PerpMarket[];
+  error?: string;
+};
+
+const VIEW_OPTIONS: { label: string; value: ViewMode }[] = [
+  { label: "Card", value: "card" },
+  { label: "List", value: "list" },
+];
+
+export default function PerpPage() {
+  const [markets, setMarkets] = useState<PerpMarket[]>([]);
+  const [view, setView] = useState<ViewMode>("card");
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMarkets = useCallback(async () => {
+    try {
+      const response = await fetch("/api/perp", {
+        cache: "no-store",
+      });
+      const payload = (await response.json()) as PerpResponse;
+
+      if (!response.ok || !payload.ok || !Array.isArray(payload.markets)) {
+        throw new Error(payload.error ?? "Failed to load markets");
+      }
+
+      setMarkets(payload.markets);
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unexpected error";
+      setError(message);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMarkets();
+    const interval = setInterval(fetchMarkets, 10_000);
+    return () => clearInterval(interval);
+  }, [fetchMarkets]);
+
+  const hasMarkets = markets.length > 0;
+
+  const marketContent = useMemo(() => {
+    if (!hasMarkets) {
+      return null;
+    }
+
+    if (view === "card") {
+      return (
+        <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+          {markets.map((market) => (
+            <Card
+              key={market.symbol}
+              className="border-slate-800 bg-slate-900/80 text-slate-100 shadow-lg shadow-slate-950/40"
+            >
+              <CardHeader className="rounded-t-2xl border-b border-slate-800/60 bg-gradient-to-r from-slate-900 via-slate-900/70 to-slate-900/90">
+                <CardTitle className="flex items-baseline justify-between text-lg font-semibold">
+                  <span>{market.symbol}</span>
+                  <span className="text-base text-slate-300">
+                    ${formatPrice(market.markPrice, market.stable)}
+                  </span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-slate-300">
+                <div className="flex items-center justify-between">
+                  <span className="text-slate-400">Funding</span>
+                  <span className={market.fundingRate >= 0 ? "text-emerald-400" : "text-rose-400"}>
+                    {formatPct(market.fundingRate)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-slate-400">Open Interest</span>
+                  <span>${formatCompact(market.openInterest)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-slate-400">24h Volume</span>
+                  <span>${formatCompact(market.volume24h)}</span>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div className="overflow-hidden rounded-2xl border border-slate-800">
+        <div className="grid grid-cols-5 gap-4 bg-slate-900/80 px-6 py-3 text-xs font-medium uppercase tracking-wide text-slate-400">
+          <span>Symbol</span>
+          <span>Price</span>
+          <span>Funding</span>
+          <span>Open Interest</span>
+          <span>24h Volume</span>
+        </div>
+        <div className="divide-y divide-slate-800 bg-slate-950/60 text-sm text-slate-200">
+          {markets.map((market) => (
+            <div
+              key={market.symbol}
+              className="grid grid-cols-5 gap-4 px-6 py-4 hover:bg-slate-900/70"
+            >
+              <span className="font-medium text-slate-100">{market.symbol}</span>
+              <span>${formatPrice(market.markPrice, market.stable)}</span>
+              <span className={market.fundingRate >= 0 ? "text-emerald-400" : "text-rose-400"}>
+                {formatPct(market.fundingRate)}
+              </span>
+              <span>${formatCompact(market.openInterest)}</span>
+              <span>${formatCompact(market.volume24h)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }, [hasMarkets, markets, view]);
+
+  return (
+    <div className="min-h-screen bg-slate-950 py-12 text-slate-100">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-3">
+            <div>
+              <h1 className="text-2xl font-semibold text-white">Perpetual Markets</h1>
+              <p className="text-sm text-slate-400">
+                Live Hyperliquid perp metrics refreshed every 10 seconds.
+              </p>
+            </div>
+            <div className="h-px w-full bg-gradient-to-r from-slate-100/0 via-slate-100/40 to-slate-100/0" />
+          </div>
+          <div className="flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900/80 p-1">
+            {VIEW_OPTIONS.map((option) => (
+              <Button
+                key={option.value}
+                variant={view === option.value ? "default" : "ghost"}
+                onClick={() => setView(option.value)}
+                className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                  view === option.value
+                    ? "bg-slate-100 text-slate-900 hover:bg-slate-200"
+                    : "text-slate-300 hover:bg-slate-800"
+                }`}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+        </header>
+
+        {error && (
+          <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+            Unable to refresh markets. {error}
+          </div>
+        )}
+
+        {hasMarkets ? (
+          marketContent
+        ) : (
+          <div className="flex h-48 items-center justify-center rounded-2xl border border-slate-800 bg-slate-900/60">
+            <p className="text-sm text-slate-400">No data yet</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// UI 스냅샷 설명: 카드/리스트 전환이 가능한 다크톤 Perp 화면과 오류/빈 상태 안내 배너.

--- a/src/data/builder.json
+++ b/src/data/builder.json
@@ -1,0 +1,30 @@
+[
+  {
+    "code": "alpha",
+    "owner": "BuilderOne",
+    "members": 128,
+    "volume24h": 1560000,
+    "estRewards": 3250
+  },
+  {
+    "code": "nova",
+    "owner": "NovaTeam",
+    "members": 86,
+    "volume24h": 2435000,
+    "estRewards": 4875
+  },
+  {
+    "code": "zenith",
+    "owner": "ZenithLabs",
+    "members": 64,
+    "volume24h": 875000,
+    "estRewards": 1940
+  },
+  {
+    "code": "delta",
+    "owner": "DeltaDAO",
+    "members": 142,
+    "volume24h": 3200000,
+    "estRewards": 5290
+  }
+]

--- a/src/server/hl/adapter.ts
+++ b/src/server/hl/adapter.ts
@@ -1,0 +1,38 @@
+import { PerpMarket } from "../../types/market";
+
+type HLMarket = {
+  name: string;
+  markPx: string;
+  funding: string;
+  openInterest: string;
+  dayNtlVlm: string;
+  isStable?: boolean;
+};
+
+const parseNumber = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  return 0;
+};
+
+export const hlToPerp = (raw: HLMarket): PerpMarket => {
+  const market: PerpMarket = {
+    symbol: raw.name,
+    markPrice: parseNumber(raw.markPx),
+    fundingRate: parseNumber(raw.funding),
+    openInterest: parseNumber(raw.openInterest),
+    volume24h: parseNumber(raw.dayNtlVlm),
+  };
+
+  if (raw.isStable) {
+    market.stable = true;
+  }
+
+  return market;
+};
+
+export type { HLMarket };

--- a/src/server/hl/fetch.ts
+++ b/src/server/hl/fetch.ts
@@ -1,0 +1,99 @@
+import type { HLMarket } from "./adapter";
+
+const REQUEST_BODY = { type: "metaAndAssetCtxs" } as const;
+const STABLE_SYMBOLS = new Set(["USDC", "USDT", "DAI", "PYUSD"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const ensureString = (value: unknown, fallback = "0"): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toString();
+  }
+
+  return fallback;
+};
+
+const normalizeMarket = (entry: unknown): HLMarket | null => {
+  if (!isRecord(entry)) {
+    return null;
+  }
+
+  const name = typeof entry.name === "string" ? entry.name : "";
+
+  return {
+    name,
+    markPx: ensureString(entry.markPx),
+    funding: ensureString(entry.funding),
+    openInterest: ensureString(entry.openInterest),
+    dayNtlVlm: ensureString(entry.dayNtlVlm),
+    isStable: name !== "" && STABLE_SYMBOLS.has(name),
+  };
+};
+
+const pickMarketList = (payload: unknown): unknown[] => {
+  if (!isRecord(payload)) {
+    return [];
+  }
+
+  const candidates: unknown[] = [];
+
+  const direct = payload.universe;
+  if (Array.isArray(direct)) {
+    candidates.push(...direct);
+  }
+
+  const perpMeta = isRecord(payload.perpMeta) ? payload.perpMeta.universe : undefined;
+  if (Array.isArray(perpMeta)) {
+    candidates.push(...perpMeta);
+  }
+
+  const meta = isRecord(payload.meta) ? payload.meta : null;
+  const metaUniverse = meta && isRecord(meta.perpMeta) ? meta.perpMeta.universe : undefined;
+  if (Array.isArray(metaUniverse)) {
+    candidates.push(...metaUniverse);
+  }
+
+  return candidates;
+};
+
+export async function fetchHLMarkets(): Promise<HLMarket[]> {
+  const endpoint = process.env.HL_REST;
+
+  if (!endpoint) {
+    throw new Error("HL_REST environment variable is not set");
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(REQUEST_BODY),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch HL markets: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+  const rawMarkets = pickMarketList(payload);
+
+  const markets: HLMarket[] = [];
+
+  for (const entry of rawMarkets) {
+    const normalized = normalizeMarket(entry);
+
+    if (normalized) {
+      markets.push(normalized);
+    }
+  }
+
+  return markets;
+}
+
+// 주의해야 할 응답 필드: universe, perpMeta.universe, meta.perpMeta.universe, markPx, funding, openInterest, dayNtlVlm, name

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -1,0 +1,8 @@
+export interface PerpMarket {
+  symbol: string;
+  markPrice: number;
+  fundingRate: number;
+  openInterest: number;
+  volume24h: number;
+  stable?: boolean;
+}

--- a/src/utils/format/number.test.ts
+++ b/src/utils/format/number.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Temporary runtime validation script for number formatting helpers.
+ * Not included in production build.
+ *
+ * Usage example (from project root):
+ *   npx ts-node src/utils/format/number.test.ts
+ */
+
+import { formatCompact, formatPct, formatPrice } from "./number";
+
+type TestCase = {
+  label: string;
+  expected: string;
+  actual: string;
+};
+
+const tests: TestCase[] = [
+  {
+    label: "formatCompact(1_234_567)",
+    expected: "1.23M",
+    actual: formatCompact(1_234_567),
+  },
+  {
+    label: "formatCompact(2_000_000_000)",
+    expected: "2B",
+    actual: formatCompact(2_000_000_000),
+  },
+  {
+    label: "formatPrice(1.2345, true)",
+    expected: "1.23",
+    actual: formatPrice(1.2345, true),
+  },
+  {
+    label: "formatPrice(123.45, false)",
+    expected: "123",
+    actual: formatPrice(123.45, false),
+  },
+  {
+    label: "formatPrice(12.345, false)",
+    expected: "12.35",
+    actual: formatPrice(12.345, false),
+  },
+  {
+    label: "formatPct(0.001234)",
+    expected: "0.123%",
+    actual: formatPct(0.001234),
+  },
+];
+
+let hasFailure = false;
+
+for (const { label, expected, actual } of tests) {
+  if (actual !== expected) {
+    hasFailure = true;
+    console.error(`❌ ${label} => "${actual}" (expected "${expected}")`);
+  } else {
+    console.log(`✅ ${label} => "${actual}"`);
+  }
+}
+
+if (hasFailure) {
+  throw new Error("One or more number format checks failed. Inspect the logs above.");
+}

--- a/src/utils/format/number.ts
+++ b/src/utils/format/number.ts
@@ -1,0 +1,72 @@
+const COMPACT_THRESHOLDS = [
+  { value: 1_000_000_000, suffix: "B" },
+  { value: 1_000_000, suffix: "M" },
+];
+
+const FALLBACK_VALUE = "—";
+
+const removeTrailingZeros = (value: string): string => {
+  return value.replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+};
+
+const isValidNumber = (value: unknown): value is number => {
+  return typeof value === "number" && Number.isFinite(value);
+};
+
+export const formatCompact = (n: number): string => {
+  if (!isValidNumber(n)) {
+    return FALLBACK_VALUE;
+  }
+
+  for (const { value, suffix } of COMPACT_THRESHOLDS) {
+    if (Math.abs(n) >= value) {
+      const formatted = (n / value).toFixed(2);
+      return `${removeTrailingZeros(formatted)}${suffix}`;
+    }
+  }
+
+  return n.toLocaleString();
+};
+
+const clampPrecision = (value: number, digits: number): string => {
+  return removeTrailingZeros(value.toFixed(digits));
+};
+
+const formatSignificant = (value: number, significant: number): string => {
+  if (value === 0) {
+    return "0";
+  }
+
+  const digits = significant - Math.floor(Math.log10(Math.abs(value))) - 1;
+  const precision = Math.max(digits, 0);
+  return removeTrailingZeros(value.toFixed(precision));
+};
+
+export const formatPrice = (n: number, stable?: boolean): string => {
+  if (!isValidNumber(n)) {
+    return FALLBACK_VALUE;
+  }
+
+  if (stable) {
+    return n.toFixed(2);
+  }
+
+  const absValue = Math.abs(n);
+  if (absValue >= 100) {
+    return Math.round(n).toString();
+  }
+
+  if (absValue >= 1) {
+    return clampPrecision(n, 2);
+  }
+
+  return formatSignificant(n, 3);
+};
+
+export const formatPct = (n: number): string => {
+  if (!isValidNumber(n)) {
+    return FALLBACK_VALUE;
+  }
+
+  return `${(n * 100).toFixed(3)}%`;
+};


### PR DESCRIPTION
## Summary
- add a gradient baseline beneath the perp header to separate the hero copy
- give perp market cards a subtle top bar gradient to improve hierarchy
- highlight the builder leaderboard header row with a gentle dark gradient

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da929c11588330a430e9c4f44a52d3