### PR TITLE
Add AI red teaming blog content calendar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-- 👋 Hi, I’m @Joonsense
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# AI Red Teaming Landing Page (Next.js)
 
-Python, ML, Finance, Marketing, 
-Blockchain, Trend, Idea, Business
+고신뢰 B2B 랜딩페이지(Physical AI/Agentic AI 대상 Red Teaming)를 Next.js(App Router) + TypeScript + Tailwind + shadcn/ui 스타일 컴포넌트로 구현했습니다.
 
-<!---
-Joonsense/Joonsense is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## 구조
+- `src/app/page.tsx`: 홈 랜딩 페이지(섹션 순서 고정: Hero → Problem → What we test → Deliverables → Packages → Process → Trust → FAQ → Final CTA)
+- `src/content/copy.ts`: 모든 하드코딩 카피를 분리한 상수 모음
+- `src/components/sections/*`: 섹션별 프레젠테이션 컴포넌트
+- `src/components/ui/*`: shadcn/ui 스타일의 버튼, 카드, 배지, 아코디언, 탭, 구분선, 다이얼로그 등 기본 UI
+- `src/app/globals.css`: Tailwind 설정 및 글로벌 스타일
+
+## 실행 방법
+```bash
+npm install
+npm run dev
+```
+`http://localhost:3000`에서 확인할 수 있습니다. 빌드는 `npm run build`, 린트는 `npm run lint`를 사용합니다.

--- a/docs/blog-content-plan.md
+++ b/docs/blog-content-plan.md
@@ -1,0 +1,99 @@
+# AI Red Teaming 월간 블로그 콘텐츠 캘린더 (8편)
+
+## 개요
+- 대상: Physical AI(물리 AI)·Agentic AI(에이전트형 AI) 보안/안전 리더, 엔지니어링 매니저, 제품 책임자
+- 목표: 검색 트래픽 → 리드(상담/견적) 전환. 모든 글은 **Evidence Pack(증빙 패키지)·Executive-ready Report(경영진용 리포트)·Retest Loop(정기 재테스트)** 중심 가치 제안으로 귀결
+- 톤: 정교하고 강한 신뢰감, 과장 없음, 법률/규제 단정 표현 금지
+
+## 주차별 8편 캘린더
+
+### Week 1
+1. **타겟 키워드:** "Physical AI Red Teaming" (물리 AI 레드팀) / "robot safety stress test" (로봇 안전 스트레스 테스트)  
+   **Search Intent(검색 의도):** 정보 탐색 – 배포 전 로봇/휴머노이드 안전 리스크 확인 방법
+   **아웃라인(H2/H3):**
+   - H2: 왜 Physical AI는 별도 레드팀이 필요한가
+     - H3: 센서/액추에이터 경로에서 발생하는 오작동 리스크
+     - H3: 시나리오 기반 행동 유도(Adversarial Prompting for Motion)
+   - H2: 우리가 테스트하는 5대 축 (Perception, Planning, Control, Safety Overrides, Fail-safe)
+   - H2: 테스트 결과 산출물 – Scorecard(점수표)와 Failure Path(실패 경로) 사례
+   - H2: 배포 전 어떻게 Release Gate(배포 게이트)를 설계할까
+   **CTA 위치:** 마지막 H2 이후 “무료 Risk Snapshot(리스크 스냅샷) 미팅 신청” 버튼
+   **Lead Magnet(리드 자석):** Physical AI Pre-Deployment 체크리스트 (PDF)
+
+2. **타겟 키워드:** "Agentic AI risk assessment" (에이전트형 AI 리스크 평가) / "AI agent red team" (AI 에이전트 레드팀)  
+   **Search Intent(검색 의도):** 정보 탐색 – 자율 에이전트의 행동 리스크와 대응
+   **아웃라인(H2/H3):**
+   - H2: Agentic AI의 행동 표면(Behavior Surface)을 정의하는 3요소
+   - H2: 사회공학/권한 상승/데이터 유출 시나리오 스트레스 테스트
+   - H2: Observability(가시성)와 Telemetry(원격 계측) 요구사항
+   - H2: Retest Loop(정기 재테스트)로 정책 회귀 방지
+   **CTA 위치:** Observability 섹션 후, 그리고 결론부에 2회 배치
+   **Lead Magnet:** Agentic AI 대응 플레이북 템플릿 (문서)
+
+### Week 2
+3. **타겟 키워드:** "AI red teaming deliverables" (AI 레드팀 산출물) / "evidence pack" (증빙 패키지)  
+   **Search Intent:** 비교/평가 – 레드팀 서비스 선택 시 산출물 기준 확인
+   **아웃라인:**
+   - H2: Evidence Pack(증빙 패키지)에 포함해야 할 최소 요건
+   - H2: Executive-ready Report(경영진용 리포트) 구조 예시
+   - H2: Heatmap(히트맵)과 Scorecard(점수표) 해석 가이드
+   - H2: Retest 결과 추적과 감사 로그
+   **CTA 위치:** Heatmap 섹션 하단 “샘플 리포트 요청”
+   **Lead Magnet:** Evidence Pack 샘플 목차 + 체크리스트
+
+4. **타겟 키워드:** "Release Gate for AI" (AI 배포 게이트) / "pre-deployment AI testing" (배포 전 AI 테스트)  
+   **Search Intent:** 상업적 – 배포 전 검증 프로세스 구축 방법
+   **아웃라인:**
+   - H2: Release Gate(배포 게이트) 설계 원칙 – Criteria(기준)·Controls(통제)·Escalation(승인)
+   - H2: 시나리오 기반 테스트 케이스 예시 (Physical / Agentic)
+   - H2: 테스트를 운영 자동화에 연결하기 (CI/CD 연계)
+   - H2: 게이트 실패 시 Fix Guide(수정 가이드) 활용 흐름
+   **CTA 위치:** 게이트 설계 원칙 직후 상담 CTA, 결론부에 재배치
+   **Lead Magnet:** Release Gate 템플릿 (스프레드시트)
+
+### Week 3
+5. **타겟 키워드:** "AI incident readiness" (AI 사고 대비) / "posture assessment" (보안 거버넌스 점검)  
+   **Search Intent:** 상업적 – 사고 대비 패키지 검토 및 도입 결정
+   **아웃라인:**
+   - H2: Incident Readiness Package(사고 대비 패키지) 구성 요소
+   - H2: Runbook(운영 절차서)와 Simulation(모의 훈련) 설계 방법
+   - H2: 가시성 및 알림 경로 설계: Telemetry(계측)·Alerting(알림)
+   - H2: Evidence Pack과 연계한 보고 라인(경영/보안)
+   **CTA 위치:** Runbook 섹션 후 “모의 훈련 예약”
+   **Lead Magnet:** Incident Simulation 시나리오 카드 묶음
+
+6. **타겟 키워드:** "Continuous retest" (정기 재테스트) / "AI assurance" (AI 신뢰 증명)  
+   **Search Intent:** 상업적 – 장기 구독/재검증 모델 탐색
+   **아웃라인:**
+   - H2: 왜 정책/모델 업데이트 후 회귀 테스트가 필요한가
+   - H2: Continuous Retest Subscription(정기 재테스트 구독) 운영 구조
+   - H2: 데이터 수집·드리프트 모니터링 포인트
+   - H2: KPI 제안: MTTR, High-Risk Finding Closure Rate, False Positive Rate
+   **CTA 위치:** KPI 섹션 후, 결론부에 재배치
+   **Lead Magnet:** 분기별 Retest 계획 템플릿 (캘린더)
+
+### Week 4
+7. **타겟 키워드:** "robot safety checklist" (로봇 안전 체크리스트) / "humanoid deployment risks" (휴머노이드 배포 리스크)  
+   **Search Intent:** 트랜잭션 – 당장 활용 가능한 체크리스트 확보
+   **아웃라인:**
+   - H2: 현장 배포 전 점검해야 할 센서/네트워크/액추에이터 항목
+   - H2: 인적 상호작용(작업자/고객) 안전 시나리오
+   - H2: Fail-safe(안전정지) 및 Override(우회) 테스트 지점
+   - H2: 증빙 확보와 감사 로그 관리
+   **CTA 위치:** 체크리스트 다운로드 버튼(상단/하단 2회)
+   **Lead Magnet:** 로봇 배포 전 30개 항목 체크리스트 (PDF)
+
+8. **타겟 키워드:** "AI red team case study" (AI 레드팀 사례) / "behavior stress test" (행동 스트레스 테스트)  
+   **Search Intent:** 상업적 – 실제 적용 사례와 효과 검증
+   **아웃라인:**
+   - H2: 초기 상태와 목표 정의 (Physical AI/Agentic AI 각 1사례)
+   - H2: 테스트 설계 – Threat Model(위협 모델)·Abuse Cases(오남용 케이스)
+   - H2: 주요 Finding(발견)와 Fix Guide 적용 흐름
+   - H2: Retest Loop에서 개선된 KPI
+   **CTA 위치:** 사례 요약 후 “Risk Snapshot 미팅” CTA
+   **Lead Magnet:** 케이스 스터디 요약본(슬라이드)
+
+## 공통 작성 가이드
+- 모든 본문은 한국어 중심, 영어 키워드는 괄호로 의미 병기
+- 법률/규제 단정 표현 금지, “보장/인증” 대신 “검증, 평가, 시나리오 기반 테스트” 표현 사용
+- 각 글의 마지막 단락에 서비스 5종(코어/배포 게이트/증빙/사고 대비/정기 재테스트)을 자연스럽게 연결

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "joonsense",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "npm run lint"
+  },
+  "dependencies": {
+    "clsx": "2.1.0",
+    "tailwind-merge": "2.2.2",
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.21",
+    "@types/react": "18.2.79",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import fs from "fs/promises";
+import path from "path";
+
+export type LeadFormState = {
+  success: boolean;
+  message?: string;
+};
+
+export async function submitLead(
+  _prevState: LeadFormState,
+  formData: FormData,
+): Promise<LeadFormState> {
+  try {
+    const payload = {
+      company: (formData.get("company") as string)?.trim(),
+      productType: (formData.get("productType") as string)?.trim(),
+      deploymentStage: (formData.get("deploymentStage") as string)?.trim(),
+      concerns: formData.getAll("concerns").map((entry) => String(entry)),
+      timeline: (formData.get("timeline") as string)?.trim(),
+      email: (formData.get("email") as string)?.trim(),
+      message: (formData.get("message") as string)?.trim(),
+      createdAt: new Date().toISOString(),
+    };
+
+    const dir = path.join(process.cwd(), "tmp", "leads");
+    await fs.mkdir(dir, { recursive: true });
+    const targetFile = path.join(dir, "leads.jsonl");
+    await fs.appendFile(targetFile, `${JSON.stringify(payload)}\n`, "utf-8");
+
+    return { success: true, message: "리드가 저장되었습니다." };
+  } catch (error) {
+    console.error("lead save error", error);
+    return { success: false, message: "제출 처리 중 문제가 발생했습니다." };
+  }
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,75 @@
+import { LeadForm } from "@/components/contact/LeadForm";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { contact } from "@/content/copy";
+
+export const metadata = {
+  title: "Contact | AI Red Teaming",
+  description: "AI 레드팀 서비스 상담: Physical AI·Agentic AI 행동 리스크를 사전 검증합니다.",
+};
+
+export default function ContactPage() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-6">
+          <Badge>{contact.heading}</Badge>
+          <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
+            {contact.heroTitle}
+          </h1>
+          <p className="text-lg text-muted-foreground sm:text-xl">{contact.heroSubtitle}</p>
+          <div className="rounded-2xl border border-border/70 bg-slate-950/60 p-6 shadow-lg">
+            <div className="space-y-4">
+              <div>
+                <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
+                  Lead Checklist
+                </p>
+                <h2 className="mt-2 text-xl font-semibold text-foreground">
+                  Evidence-ready Intake(증빙 준비형 접수)
+                </h2>
+              </div>
+              <Separator />
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {contact.leadBullets.map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-gradient-to-br from-blue-500 to-cyan-400" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="rounded-lg border border-border/70 bg-background/60 p-4 text-sm text-foreground">
+                <p className="font-semibold text-foreground">포함 정보</p>
+                <p className="text-muted-foreground">
+                  제품 유형, 배포 일정, 우려 리스크를 중심으로 알려주세요. 기밀 자료 없이도 스코핑 가능합니다.
+                </p>
+              </div>
+              <Card className="border border-accent/30 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900">
+                <div className="space-y-3 p-5 text-sm text-muted-foreground">
+                  <p className="text-xs uppercase tracking-[0.18em] text-accent">Risk snapshot</p>
+                  <p className="text-lg font-semibold text-foreground">
+                    30분 동안 현재 상태와 Release Gate(배포 게이트) 준비도를 빠르게 점검합니다.
+                  </p>
+                  <p>테스트 범위·일정을 합의하면 바로 Evidence Pack(증빙 패키지) 샘플을 공유합니다.</p>
+                </div>
+              </Card>
+            </div>
+          </div>
+        </div>
+
+        <Card className="border border-border/70 bg-slate-950/70 p-6 shadow-xl">
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-foreground">상담 요청</h2>
+            <p className="text-sm text-muted-foreground">
+              Pricing은 범위로 안내되며, 구체 견적은 테스트 범위 정의 후 제공됩니다.
+            </p>
+          </div>
+          <Separator className="my-4" />
+          <LeadForm concerns={contact.concerns} />
+          <Separator className="my-6" />
+          <p className="text-xs text-muted-foreground">{contact.privacyNote}</p>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,66 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 224 71% 4%;
+  --foreground: 210 40% 98%;
+  --muted: 215 16% 20%;
+  --muted-foreground: 217 15% 65%;
+  --accent: 217 91% 60%;
+  --accent-foreground: 210 40% 98%;
+  --primary: 217 91% 60%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 215 28% 17%;
+  --secondary-foreground: 210 40% 98%;
+  --border: 215 19% 23%;
+  --input: 215 19% 23%;
+  --ring: 217 91% 60%;
+  --radius: 0.75rem;
+}
+
+body {
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.12), transparent 22%),
+    #020617;
+  color: hsl(var(--foreground));
+  font-family: theme("fontFamily.sans");
+  min-height: 100vh;
+}
+
+.container-edge {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+.section-shell {
+  padding: 96px 0;
+}
+
+@media (max-width: 768px) {
+  .section-shell {
+    padding: 72px 0;
+  }
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: hsl(var(--accent));
+}
+
+.gradient-border {
+  position: relative;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.5), rgba(236, 72, 153, 0.5));
+  padding: 1px;
+}
+
+.gradient-border > .inner {
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.9);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "AI Red Teaming | Physical & Agentic AI Stress Test",
+  description:
+    "Physical AI와 Agentic AI를 위한 기술적 행동 스트레스 테스트 및 신뢰 증빙 랜딩페이지.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ko">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,25 @@
+import { HeroSection } from "@/components/sections/Hero";
+import { ProblemSection } from "@/components/sections/Problem";
+import { WhatWeTestSection } from "@/components/sections/WhatWeTest";
+import { DeliverablesSection } from "@/components/sections/Deliverables";
+import { PackagesSection } from "@/components/sections/Packages";
+import { ProcessSection } from "@/components/sections/Process";
+import { TrustSection } from "@/components/sections/Trust";
+import { FAQSection } from "@/components/sections/FAQ";
+import { FinalCTASection } from "@/components/sections/FinalCTA";
+
+export default function HomePage() {
+  return (
+    <main className="space-y-4">
+      <HeroSection />
+      <ProblemSection />
+      <WhatWeTestSection />
+      <DeliverablesSection />
+      <PackagesSection />
+      <ProcessSection />
+      <TrustSection />
+      <FAQSection />
+      <FinalCTASection />
+    </main>
+  );
+}

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { servicesPage } from "@/content/copy";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+const buttonBase =
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring";
+
+export default function ServiceDetailPage({ params }: { params: { slug: string } }) {
+  const service = servicesPage.items.find((item) => item.slug === params.slug);
+
+  if (!service) {
+    notFound();
+  }
+
+  return (
+    <main className="space-y-10">
+      <section className="section-shell">
+        <div className="container-edge space-y-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge variant="outline">서비스 상세</Badge>
+            <Badge>{service.priceRange}</Badge>
+            <Badge variant="outline">기간 {service.duration}</Badge>
+          </div>
+
+          <div className="space-y-3">
+            <h1 className="text-4xl font-semibold leading-tight">{service.name}</h1>
+            <p className="text-lg text-muted-foreground">{service.tagline}</p>
+            <p className="text-muted-foreground">추천 대상: {service.recommended}</p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/contact"
+              className={cn(buttonBase, "bg-primary px-5 py-3 text-primary-foreground hover:bg-blue-500/90")}
+            >
+              상담 문의
+            </Link>
+            <Link
+              href="/services"
+              className={cn(buttonBase, "border border-border px-5 py-3 text-foreground hover:bg-muted/50")}
+            >
+              서비스 목록으로
+            </Link>
+          </div>
+
+          <Separator className="bg-border/60" />
+
+          <div className="grid gap-6 lg:grid-cols-3">
+            <Card className="space-y-3">
+              <h2 className="text-lg font-semibold">Deliverables (산출물)</h2>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                {service.deliverables.map((item) => (
+                  <li key={item} className="leading-relaxed">· {item}</li>
+                ))}
+              </ul>
+            </Card>
+
+            <Card className="space-y-3">
+              <h2 className="text-lg font-semibold">포함</h2>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                {service.includes.map((item) => (
+                  <li key={item} className="leading-relaxed">· {item}</li>
+                ))}
+              </ul>
+            </Card>
+
+            <Card className="space-y-3">
+              <h2 className="text-lg font-semibold">미포함</h2>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                {service.excludes.map((item) => (
+                  <li key={item} className="leading-relaxed">· {item}</li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+
+          <Card className="space-y-4">
+            <div>
+              <h2 className="text-lg font-semibold">가격 및 기간</h2>
+              <p className="text-sm text-muted-foreground">{servicesPage.note}</p>
+            </div>
+            <div className="grid gap-3 text-sm text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
+              <Info label="가격 범위" value={service.priceRange} />
+              <Info label="예상 기간" value={service.duration} />
+              <Info label="포함 항목 수" value={`${service.includes.length}개`} />
+              <Info label="산출물" value={`${service.deliverables.length}개 핵심 결과물`} />
+            </div>
+            <Separator className="bg-border/60" />
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/contact"
+                className={cn(buttonBase, "bg-primary px-5 py-3 text-primary-foreground hover:bg-blue-500/90")}
+              >
+                견적 및 일정 확인
+              </Link>
+              <Link
+                href="/services"
+                className={cn(buttonBase, "border border-border px-5 py-3 text-foreground hover:bg-muted/50")}
+              >
+                다른 서비스 비교
+              </Link>
+            </div>
+          </Card>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function Info({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{label}</p>
+      <p className="text-foreground">{value}</p>
+    </div>
+  );
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { servicesPage } from "@/content/copy";
+import { ServiceCard } from "@/components/services/ServiceCard";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+const buttonBase =
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring";
+
+export default function ServicesPage() {
+  return (
+    <main className="space-y-10">
+      <section className="section-shell">
+        <div className="container-edge space-y-6">
+          <div className="space-y-3">
+            <Badge variant="outline">Services</Badge>
+            <h1 className="text-4xl font-semibold leading-tight">{servicesPage.hero.title}</h1>
+            <p className="max-w-3xl text-lg text-muted-foreground">{servicesPage.hero.subtitle}</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link href="/contact" className={cn(buttonBase, "bg-primary px-5 py-3 text-primary-foreground hover:bg-blue-500/90")}> 
+              {servicesPage.hero.primaryCta}
+            </Link>
+            <Link href="#service-list" className={cn(buttonBase, "border border-border px-5 py-3 text-foreground hover:bg-muted/50")}> 
+              {servicesPage.hero.secondaryCta}
+            </Link>
+          </div>
+          <p className="text-sm text-muted-foreground">{servicesPage.note}</p>
+        </div>
+      </section>
+
+      <section id="service-list" className="section-shell pt-0">
+        <div className="container-edge space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-2xl font-semibold">서비스 라인업</h2>
+              <p className="text-muted-foreground">각 서비스별 포함/미포함, 산출물, 기간을 빠르게 비교하세요.</p>
+            </div>
+            <Badge variant="outline">5 services</Badge>
+          </div>
+          <Separator className="bg-border/60" />
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {servicesPage.items.map((service) => (
+              <ServiceCard key={service.slug} service={service} />
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/contact/LeadForm.tsx
+++ b/src/components/contact/LeadForm.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useFormState, useFormStatus } from "react-dom";
+import { submitLead, type LeadFormState } from "@/app/contact/actions";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+const initialState: LeadFormState = { success: false };
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" size="lg" className="w-full" disabled={pending}>
+      {pending ? "제출 중..." : "문의 보내기"}
+    </Button>
+  );
+}
+
+export function LeadForm({ concerns }: { concerns: string[] }) {
+  const [state, formAction] = useFormState(submitLead, initialState);
+
+  return (
+    <form action={formAction} className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">회사명</label>
+          <input
+            name="company"
+            required
+            className="input"
+            placeholder="법인/팀 이름"
+            autoComplete="organization"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">제품 유형</label>
+          <select name="productType" required className="input">
+            <option value="">선택하세요</option>
+            <option value="Robot">로봇/휴머노이드</option>
+            <option value="Agent">에이전트형 AI</option>
+            <option value="LLM">LLM 앱/오케스트레이션</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">배포 단계</label>
+          <select name="deploymentStage" required className="input">
+            <option value="">선택하세요</option>
+            <option value="Development">개발</option>
+            <option value="PoC">PoC/파일럿</option>
+            <option value="Production">상용/운영</option>
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">희망 일정</label>
+          <input
+            name="timeline"
+            required
+            className="input"
+            placeholder="예: 2주 내 리포트 필요"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <label className="text-sm font-medium">우려사항 (복수 선택)</label>
+          <Badge variant="outline">리스트 기반</Badge>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {concerns.map((item) => (
+            <label
+              key={item}
+              className="flex items-start gap-2 rounded-lg border border-border/70 bg-background/60 p-3 text-sm"
+            >
+              <input
+                type="checkbox"
+                name="concerns"
+                value={item}
+                className="mt-1 h-4 w-4 rounded border-border"
+              />
+              <span>{item}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">이메일</label>
+          <input
+            name="email"
+            type="email"
+            required
+            className="input"
+            placeholder="work@example.com"
+            autoComplete="email"
+          />
+        </div>
+        <div className="space-y-2 sm:col-span-2">
+          <label className="text-sm font-medium">메시지</label>
+          <textarea
+            name="message"
+            required
+            className="input min-h-[120px]"
+            placeholder="시스템 구성, 테스트 희망 범위, 보안 요구사항 등을 남겨주세요"
+          />
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border/60 bg-slate-950/60 p-4 text-sm text-muted-foreground">
+        개인정보·민감정보 업로드 금지. 테스트용 더미 데이터나 추상화된 설명으로 공유해주세요.
+      </div>
+
+      <div className="space-y-3">
+        <SubmitButton />
+        {state.success && (
+          <div className="rounded-lg border border-green-500/40 bg-green-500/10 p-4 text-sm text-foreground">
+            Risk Snapshot(리스크 스냅샷) 미팅을 제안했습니다. 24시간 내 일정 확인 메일을 보내드립니다.
+          </div>
+        )}
+        {!state.success && state.message && (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            {state.message}
+          </div>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/components/sections/Deliverables.tsx
+++ b/src/components/sections/Deliverables.tsx
@@ -1,0 +1,37 @@
+import { deliverables } from "@/content/copy";
+import { Tabs } from "@/components/ui/tabs";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+export function DeliverablesSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge space-y-10">
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent">Deliverables</p>
+          <h2 className="text-3xl font-semibold sm:text-4xl">{deliverables.heading}</h2>
+          <p className="text-lg text-muted-foreground">{deliverables.intro}</p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+          <Tabs
+            defaultActiveId={deliverables.items[0]?.title}
+            tabs={deliverables.items.map((item) => ({
+              id: item.title,
+              label: item.title,
+              content: item.description,
+            }))}
+          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            {deliverables.items.map((item) => (
+              <Card key={item.title} className="h-full">
+                <CardHeader>
+                  <CardTitle>{item.title}</CardTitle>
+                  <CardDescription>{item.description}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/FAQ.tsx
+++ b/src/components/sections/FAQ.tsx
@@ -1,0 +1,23 @@
+import { faq } from "@/content/copy";
+import { Accordion } from "@/components/ui/accordion";
+
+export function FAQSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge space-y-8">
+        <div className="space-y-3 text-center">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent">FAQ</p>
+          <h2 className="text-3xl font-semibold sm:text-4xl">{faq.heading}</h2>
+          <p className="text-lg text-muted-foreground">가장 많이 받는 질문을 모았습니다.</p>
+        </div>
+        <Accordion
+          items={faq.items.map((item, idx) => ({
+            value: `faq-${idx}`,
+            title: item.question,
+            content: item.answer,
+          }))}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/FinalCTA.tsx
+++ b/src/components/sections/FinalCTA.tsx
@@ -1,0 +1,25 @@
+import { finalCta } from "@/content/copy";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export function FinalCTASection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge">
+        <Card className="bg-gradient-to-r from-slate-900/80 via-slate-900/70 to-slate-900/50 p-8 text-center">
+          <div className="space-y-4 sm:space-y-6">
+            <p className="text-sm uppercase tracking-[0.2em] text-accent">Get started</p>
+            <h2 className="text-3xl font-semibold sm:text-4xl">{finalCta.heading}</h2>
+            <p className="text-lg text-muted-foreground">{finalCta.subheading}</p>
+            <div className="flex flex-wrap items-center justify-center gap-4">
+              <Button size="lg">{finalCta.primaryCta}</Button>
+              <Button size="lg" variant="outline">
+                {finalCta.secondaryCta}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,102 @@
+import { hero } from "@/content/copy";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Dialog } from "@/components/ui/dialog";
+
+export function HeroSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge">
+        <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-6 lg:max-w-2xl">
+            <Badge>{hero.eyebrow}</Badge>
+            <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
+              {hero.title}
+            </h1>
+            <p className="text-lg text-muted-foreground sm:text-xl">{hero.subtitle}</p>
+            <div className="flex flex-wrap gap-4">
+              <Button size="lg">{hero.primaryCta}</Button>
+              <Dialog
+                trigger={<Button size="lg" variant="ghost">{hero.secondaryCta}</Button>}
+                title="샘플 리포트 미리보기"
+                description="기밀 정보 없이 형식과 깊이를 확인할 수 있는 요약본입니다."
+              >
+                <ul className="list-disc space-y-2 pl-5">
+                  <li>Executive-ready Report(경영진용 리포트) 목차</li>
+                  <li>Scorecard·Heatmap 요약 샘플</li>
+                  <li>Failure Path(실패 경로) 기록 예시</li>
+                </ul>
+              </Dialog>
+            </div>
+            <div className="flex flex-wrap gap-6 text-sm text-muted-foreground">
+              <div>
+                <p className="font-semibold text-foreground">Physical AI · Agentic AI 전문</p>
+                <p>로봇·에이전트 특화 스트레스 테스트 자산 보유</p>
+              </div>
+              <div>
+                <p className="font-semibold text-foreground">Evidence-first</p>
+                <p>Evidence Pack(증빙 패키지)로 신뢰를 증명</p>
+              </div>
+            </div>
+          </div>
+          <div className="gradient-border w-full max-w-xl">
+            <div className="inner rounded-2xl p-6">
+              <div className="space-y-4">
+                <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">Behavior Stress Dashboard</p>
+                <div className="rounded-xl border border-border/60 bg-slate-950/60 p-4 shadow-inner">
+                  <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>Release Gate(배포 게이트) 준비도</span>
+                    <span className="text-xs text-accent">updated 4h ago</span>
+                  </div>
+                  <div className="mt-3 flex items-center gap-3">
+                    <div className="h-16 w-16 rounded-full bg-gradient-to-br from-blue-500 to-cyan-400 text-center text-xl font-bold leading-[64px] text-slate-950">
+                      92%
+                    </div>
+                    <div className="flex-1">
+                      <div className="mb-2 h-2 rounded-full bg-slate-800">
+                        <div className="h-2 w-[92%] rounded-full bg-gradient-to-r from-blue-500 to-cyan-400" />
+                      </div>
+                      <p className="text-sm text-muted-foreground">취약점 3건, 대응 가이드 전달 완료</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3 text-sm text-muted-foreground sm:grid-cols-3">
+                  <div className="rounded-lg border border-border/60 bg-slate-950/60 p-3">
+                    <p className="text-xs uppercase tracking-widest">Physical AI</p>
+                    <p className="mt-2 text-foreground">Collision & fall</p>
+                    <p>PASS</p>
+                  </div>
+                  <div className="rounded-lg border border-border/60 bg-slate-950/60 p-3">
+                    <p className="text-xs uppercase tracking-widest">Agentic</p>
+                    <p className="mt-2 text-foreground">Tool misuse</p>
+                    <p>2 findings</p>
+                  </div>
+                  <div className="rounded-lg border border-border/60 bg-slate-950/60 p-3">
+                    <p className="text-xs uppercase tracking-widest">Adversarial</p>
+                    <p className="mt-2 text-foreground">Prompt injection</p>
+                    <p>Watch</p>
+                  </div>
+                  <div className="rounded-lg border border-border/60 bg-slate-950/60 p-3">
+                    <p className="text-xs uppercase tracking-widest">Integration</p>
+                    <p className="mt-2 text-foreground">API/PLC</p>
+                    <p>Stable</p>
+                  </div>
+                  <div className="rounded-lg border border-border/60 bg-slate-950/60 p-3">
+                    <p className="text-xs uppercase tracking-widest">Retest</p>
+                    <p className="mt-2 text-foreground">Loop</p>
+                    <p>scheduled</p>
+                  </div>
+                  <div className="rounded-lg border border-border/60 bg-slate-950/60 p-3">
+                    <p className="text-xs uppercase tracking-widest">Evidence</p>
+                    <p className="mt-2 text-foreground">Pack</p>
+                    <p>Ready</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Packages.tsx
+++ b/src/components/sections/Packages.tsx
@@ -1,0 +1,46 @@
+import { packages } from "@/content/copy";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+export function PackagesSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge space-y-10">
+        <div className="space-y-3 text-center">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent">Packages</p>
+          <h2 className="text-3xl font-semibold sm:text-4xl">{packages.heading}</h2>
+          <p className="text-lg text-muted-foreground">{packages.description}</p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {packages.tiers.map((tier) => (
+            <Card
+              key={tier.name}
+              className={`h-full border ${tier.highlight ? "border-accent/80 bg-slate-900/40" : "border-border/80"}`}
+            >
+              <CardHeader className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-2xl">{tier.name}</CardTitle>
+                  {tier.highlight && <Badge variant="outline">Most picked</Badge>}
+                </div>
+                <CardDescription className="text-foreground text-xl font-semibold">{tier.price}</CardDescription>
+                <CardDescription>{tier.detail}</CardDescription>
+                <div className="space-y-2 text-sm text-foreground">
+                  {tier.features.map((feature) => (
+                    <div key={feature} className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-accent" />
+                      <p>{feature}</p>
+                    </div>
+                  ))}
+                </div>
+                <Button variant={tier.highlight ? "default" : "outline"} fullWidth>
+                  상담 예약
+                </Button>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Problem.tsx
+++ b/src/components/sections/Problem.tsx
@@ -1,0 +1,34 @@
+import { problems } from "@/content/copy";
+import { Card } from "@/components/ui/card";
+
+export function ProblemSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        <div className="space-y-4">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent">Problem</p>
+          <h2 className="text-3xl font-semibold sm:text-4xl">{problems.heading}</h2>
+          <div className="space-y-4 text-lg text-muted-foreground">
+            {problems.bullets.map((item) => (
+              <div key={item} className="flex items-start gap-3">
+                <span className="mt-1 inline-block h-2 w-2 rounded-full bg-accent" />
+                <p>{item}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+        <Card className="border-accent/40 bg-gradient-to-br from-slate-900/70 via-slate-900/50 to-slate-900/30">
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <p className="text-base font-semibold text-foreground">자주 발견되는 실패 패턴</p>
+            <ul className="space-y-3">
+              <li className="rounded-lg border border-border/60 bg-slate-950/60 p-3">센서 스푸핑 상황에서 잘못된 경로 계획</li>
+              <li className="rounded-lg border border-border/60 bg-slate-950/60 p-3">에이전트가 민감 데이터에 과도 접근 후 로깅 누락</li>
+              <li className="rounded-lg border border-border/60 bg-slate-950/60 p-3">프롬프트 인젝션으로 툴 Misuse(오남용) 발생</li>
+              <li className="rounded-lg border border-border/60 bg-slate-950/60 p-3">Fail-safe(안전중지) 전환 지연으로 현장 위험 증가</li>
+            </ul>
+          </div>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Process.tsx
+++ b/src/components/sections/Process.tsx
@@ -1,0 +1,29 @@
+import { process } from "@/content/copy";
+import { Separator } from "@/components/ui/separator";
+
+export function ProcessSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge space-y-8">
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent">Process</p>
+          <h2 className="text-3xl font-semibold sm:text-4xl">{process.heading}</h2>
+        </div>
+        <div className="space-y-6">
+          {process.steps.map((step, index) => (
+            <div key={step.title} className="grid gap-4 rounded-2xl border border-border/80 bg-slate-900/60 p-5 sm:grid-cols-[0.15fr_1fr] sm:items-start">
+              <div className="flex items-center gap-3 text-sm font-semibold text-muted-foreground">
+                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-secondary text-secondary-foreground">{index + 1}</span>
+                <Separator className="hidden h-px w-16 bg-border/60 sm:block" />
+              </div>
+              <div>
+                <p className="text-lg font-semibold">{step.title}</p>
+                <p className="mt-2 text-muted-foreground">{step.detail}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Trust.tsx
+++ b/src/components/sections/Trust.tsx
@@ -1,0 +1,26 @@
+import { trust } from "@/content/copy";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function TrustSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge space-y-10">
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent">Trust</p>
+          <h2 className="text-3xl font-semibold sm:text-4xl">{trust.heading}</h2>
+          <p className="text-lg text-muted-foreground">증명 가능한 출력물과 운영 원칙으로 신뢰를 쌓습니다.</p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {trust.items.map((item) => (
+            <Card key={item.title} className="h-full">
+              <CardHeader>
+                <CardTitle>{item.title}</CardTitle>
+                <CardDescription>{item.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/WhatWeTest.tsx
+++ b/src/components/sections/WhatWeTest.tsx
@@ -1,0 +1,26 @@
+import { testCategories } from "@/content/copy";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function WhatWeTestSection() {
+  return (
+    <section className="section-shell">
+      <div className="container-edge space-y-10">
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent">What we test</p>
+          <h2 className="text-3xl font-semibold sm:text-4xl">{testCategories.heading}</h2>
+          <p className="text-lg text-muted-foreground">{testCategories.description}</p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {testCategories.categories.map((item) => (
+            <Card key={item.title} className="h-full">
+              <CardHeader>
+                <CardTitle>{item.title}</CardTitle>
+                <CardDescription>{item.detail}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/services/ServiceCard.tsx
+++ b/src/components/services/ServiceCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Card, CardDescription, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import { servicesPage } from "@/content/copy";
+
+type ServiceItem = (typeof servicesPage.items)[number];
+
+export function ServiceCard({ service }: { service: ServiceItem }) {
+  const router = useRouter();
+
+  return (
+    <Card className="flex h-full flex-col gap-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-2">
+          <CardTitle className="text-xl">{service.name}</CardTitle>
+          <CardDescription className="text-sm leading-6">{service.tagline}</CardDescription>
+        </div>
+        <Badge className="shrink-0">{service.priceRange}</Badge>
+      </div>
+
+      <div className="grid gap-3 text-sm text-muted-foreground sm:grid-cols-2">
+        <Info label="추천 대상" value={service.recommended} />
+        <Info label="기간" value={service.duration} align="end" />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Deliverables (산출물)</p>
+        <div className="flex flex-wrap gap-2">
+          {service.deliverables.map((item) => (
+            <Badge key={item} variant="outline" className="text-xs font-medium">
+              {item}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 text-sm text-muted-foreground sm:grid-cols-2">
+        <ListBlock title="포함" items={service.includes} />
+        <ListBlock title="미포함" items={service.excludes} muted />
+      </div>
+
+      <Separator className="bg-border/60" />
+
+      <div className="flex flex-wrap gap-3">
+        <Button size="sm" onClick={() => router.push(`/services/${service.slug}`)}>
+          상세 보기
+        </Button>
+        <Dialog
+          trigger={<Button size="sm" variant="outline">포함/미포함 보기</Button>}
+          title={`${service.name} 구성 상세`}
+          description={service.tagline}
+        >
+          <div className="space-y-4">
+            <ListBlock title="포함" items={service.includes} />
+            <ListBlock title="미포함" items={service.excludes} muted />
+          </div>
+        </Dialog>
+        <Button size="sm" variant="secondary" onClick={() => router.push("/contact")}>
+          상담 문의
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function Info({
+  label,
+  value,
+  align = "start",
+}: {
+  label: string;
+  value: string;
+  align?: "start" | "end";
+}) {
+  return (
+    <div className={`space-y-1 ${align === "end" ? "text-right" : "text-left"}`}>
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{label}</p>
+      <p className="text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function ListBlock({ title, items, muted }: { title: string; items: string[]; muted?: boolean }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{title}</p>
+      <ul className={`space-y-1.5 text-sm ${muted ? "text-muted-foreground" : "text-foreground"}`}>
+        {items.map((item) => (
+          <li key={item} className="leading-relaxed">
+            • {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface AccordionItemProps {
+  value: string;
+  title: string;
+  content: React.ReactNode;
+}
+
+interface AccordionProps {
+  items: AccordionItemProps[];
+}
+
+export function Accordion({ items }: AccordionProps) {
+  const [openItem, setOpenItem] = React.useState<string | null>(items[0]?.value ?? null);
+
+  return (
+    <div className="divide-y divide-border/60 border border-border/80 rounded-xl bg-slate-900/50">
+      {items.map((item) => {
+        const open = openItem === item.value;
+        return (
+          <div key={item.value} className="p-4">
+            <button
+              onClick={() => setOpenItem(open ? null : item.value)}
+              className="flex w-full items-center justify-between gap-4 text-left"
+            >
+              <span className="text-base font-semibold">{item.title}</span>
+              <span className="text-xl text-muted-foreground">{open ? "−" : "+"}</span>
+            </button>
+            {open && <div className={cn("pt-3 text-sm text-muted-foreground")}>{item.content}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: "default" | "outline";
+}
+
+export function Badge({ className, variant = "default", ...props }: BadgeProps) {
+  const variants = {
+    default: "bg-secondary text-secondary-foreground border border-border/60",
+    outline: "border border-border text-foreground",
+  };
+
+  return (
+    <span
+      className={cn("inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold", variants[variant], className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type ButtonVariant = "default" | "secondary" | "ghost" | "outline" | "muted";
+type ButtonSize = "sm" | "md" | "lg";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+}
+
+const baseClasses =
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:opacity-50 disabled:cursor-not-allowed";
+
+const variants: Record<ButtonVariant, string> = {
+  default: "bg-primary text-primary-foreground hover:bg-blue-500/90 shadow-md",
+  secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+  ghost: "bg-transparent text-foreground hover:bg-muted/60",
+  outline: "border border-border text-foreground hover:bg-muted/50",
+  muted: "bg-muted text-muted-foreground hover:text-foreground",
+};
+
+const sizes: Record<ButtonSize, string> = {
+  sm: "px-3 py-2 text-sm",
+  md: "px-4 py-2.5 text-sm",
+  lg: "px-5 py-3 text-base",
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "md", fullWidth, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        baseClasses,
+        variants[variant],
+        sizes[size],
+        fullWidth && "w-full",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Button.displayName = "Button";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border/80 bg-gradient-to-br from-slate-900/70 via-slate-900/60 to-slate-900/40 p-6 shadow-card",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mb-4 flex flex-col gap-2", className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn("text-lg font-semibold", className)} {...props} />;
+}
+
+export function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface DialogProps {
+  trigger: React.ReactNode;
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+export function Dialog({ trigger, title, description, children }: DialogProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <div onClick={() => setOpen(true)} className="inline-flex cursor-pointer">
+        {trigger}
+      </div>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-8">
+          <div className="relative w-full max-w-lg rounded-2xl border border-border/80 bg-slate-900/95 p-6 shadow-2xl">
+            <button
+              aria-label="Close dialog"
+              className="absolute right-4 top-4 text-xl text-muted-foreground hover:text-foreground"
+              onClick={() => setOpen(false)}
+            >
+              ×
+            </button>
+            <div className="space-y-3 pr-6">
+              <h3 className="text-xl font-semibold">{title}</h3>
+              {description && <p className="text-sm text-muted-foreground">{description}</p>}
+              <div className={cn("text-sm text-muted-foreground")}>{children}</div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,6 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Separator({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("h-px w-full bg-border/80", className)} {...props} />;
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface TabsProps {
+  tabs: { id: string; label: string; content: React.ReactNode }[];
+  defaultActiveId?: string;
+}
+
+export function Tabs({ tabs, defaultActiveId }: TabsProps) {
+  const [active, setActive] = React.useState(defaultActiveId ?? tabs[0]?.id ?? "");
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 rounded-xl border border-border/70 bg-slate-900/50 p-2">
+        {tabs.map((tab) => {
+          const isActive = tab.id === active;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActive(tab.id)}
+              className={cn(
+                "rounded-lg px-4 py-2 text-sm font-semibold transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground shadow"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-4 rounded-xl border border-border/70 bg-slate-900/50 p-6 text-sm text-muted-foreground">
+        {tabs.find((tab) => tab.id === active)?.content}
+      </div>
+    </div>
+  );
+}

--- a/src/content/copy.ts
+++ b/src/content/copy.ts
@@ -1,0 +1,370 @@
+export const hero = {
+  eyebrow: "AI Red Teaming for Physical & Agentic AI",
+  title: "배포 전 행동 리스크를 증명 가능한 신뢰로 전환",
+  subtitle:
+    "로봇·에이전트형 AI를 실제 운영 환경 수준으로 스트레스 테스트하고, 증빙 가능한 결과물로 의사결정을 돕습니다.",
+  primaryCta: "바로 상담하기",
+  secondaryCta: "샘플 리포트 보기",
+};
+
+export const problems = {
+  heading: "놓치기 쉬운 리스크, 운영 전에 드러내야 합니다",
+  bullets: [
+    "휴머노이드/모바일 로봇의 비정상 행동을 미리 발견해 현장 안전 비용을 줄입니다.",
+    "Agentic AI의 잘못된 의사결정을 Release Gate(배포 게이트) 이전에 차단합니다.",
+    "법률 자문이 아닌 기술적 행동 검증으로 보안팀·현업팀 간 언어를 통일합니다.",
+  ],
+};
+
+export const testCategories = {
+  heading: "What we test (우리가 테스트하는 것)",
+  description: "물리 세계와 멀티스텝 에이전트의 행동을 실제 시나리오 기반으로 검증합니다.",
+  categories: [
+    {
+      title: "Physical AI Safety",
+      detail: "충돌/추락/접촉 안전, 실패 모드 전환, 물리 센서 오류 대응",
+    },
+    {
+      title: "Agentic Decisioning",
+      detail: "Goal Misalignment(목표 불일치)·Hallucination(환각)·Tool Misuse(툴 오남용)",
+    },
+    {
+      title: "Autonomy Guardrails",
+      detail: "권한 남용, 민감 데이터 접근, 비인가 행동 경로 차단",
+    },
+    {
+      title: "Adversarial Robustness",
+      detail: "프롬프트 인젝션, 시각/음성 교란, 노이즈·스푸핑 대응",
+    },
+    {
+      title: "Integration Failures",
+      detail: "API·PLC·센서퓨전 경계값, 타임아웃/재시도 전략 검증",
+    },
+    {
+      title: "Operational Readiness",
+      detail: "모니터링 시나리오, 알림·에스컬레이션, 롤백/Fail-safe(안전중지)",
+    },
+  ],
+};
+
+export const deliverables = {
+  heading: "Deliverables (산출물)",
+  intro: "기술 검증 결과를 바로 의사결정에 사용할 수 있도록 구조화했습니다.",
+  items: [
+    {
+      title: "Scorecard (점수표)",
+      description: "리스크 카테고리별 점수와 해석 가이드로 경영진 보고를 단순화.",
+    },
+    {
+      title: "Heatmap (히트맵)",
+      description: "자산·시나리오·심각도별 리스크 분포를 한눈에 시각화.",
+    },
+    {
+      title: "Failure Path (실패 경로)",
+      description: "행동 실패가 발생한 실제 경로와 환경 조건을 재현 가능하게 기록.",
+    },
+    {
+      title: "Fix Guide (수정 가이드)",
+      description: "모델·정책·오케스트레이션별 수정 제안과 우선순위를 제시.",
+    },
+    {
+      title: "Evidence Pack (증빙 패키지)",
+      description: "로그·동영상·테스트 스크립트와 함께 Release Gate(배포 게이트) 통과 근거 제공.",
+    },
+  ],
+};
+
+export const packages = {
+  heading: "Packages",
+  description: "프로덕트 단계와 리스크 민감도에 맞춘 3가지 옵션.",
+  tiers: [
+    {
+      name: "Starter",
+      price: "$8,500",
+      detail: "단일 로봇/에이전트, 8개 시나리오, 2주 납기",
+      features: [
+        "기본 행동 스트레스 테스트",
+        "Scorecard·Heatmap 제공",
+        "1회 Retest(재테스트) 포함",
+      ],
+      highlight: false,
+    },
+    {
+      name: "Core",
+      price: "$14,000",
+      detail: "다중 에이전트/로봇, 15개 시나리오, 3주 납기",
+      features: [
+        "Adversarial·Integration 집중 검증",
+        "Evidence Pack·Failure Path 포함",
+        "2회 Retest + 대응 워크숍",
+      ],
+      highlight: true,
+    },
+    {
+      name: "Premium",
+      price: "Custom",
+      detail: "고위험 환경, 확장된 시나리오, 온사이트 옵션",
+      features: [
+        "보안팀/운영팀 합동 세션",
+        "연속 모니터링 및 Subscription(구독) 연계",
+        "Executive-ready Report(경영진용 리포트)",
+      ],
+      highlight: false,
+    },
+  ],
+};
+
+export const process = {
+  heading: "Process",
+  steps: [
+    {
+      title: "Scoping",
+      detail: "시스템 범위, 안전 임계치, 성공·실패 기준 정의",
+    },
+    {
+      title: "Threat & Scenario Modeling",
+      detail: "물리/에이전트형 위협 모델링과 테스트 스크립트 설계",
+    },
+    {
+      title: "Execution",
+      detail: "현장 조건을 모사한 스트레스 테스트와 로그 수집",
+    },
+    {
+      title: "Analysis",
+      detail: "리스크 분포 Heatmap과 Failure Path 재현 검증",
+    },
+    {
+      title: "Guidance",
+      detail: "Fix Guide(수정 가이드)와 Release Gate(배포 게이트) 추천 기준 제공",
+    },
+    {
+      title: "Retest Loop",
+      detail: "수정 후 재테스트와 Evidence Pack 업데이트",
+    },
+  ],
+};
+
+export const trust = {
+  heading: "Trust",
+  items: [
+    {
+      title: "Certificate (증서)",
+      description: "테스트 완료 후 Verified Behavior Test Certificate(검증 완료 증서) 발급",
+    },
+    {
+      title: "Retest Policy (재테스트 정책)",
+      description: "변경 발생 시 신속한 재검증과 업데이트된 Evidence Pack 제공",
+    },
+    {
+      title: "Security Posture (보안 운영 원칙)",
+      description: "데이터 최소 수집, 격리된 테스트 환경, 접근 통제 로그를 준수",
+    },
+  ],
+};
+
+export const faq = {
+  heading: "FAQ",
+  items: [
+    {
+      question: "법률 자문이나 규제 인증을 제공하나요?",
+      answer: "아니요. 우리는 기술적 행동 검증과 증빙 자료만을 제공합니다. 법적 보장은 하지 않습니다.",
+    },
+    {
+      question: "물리 로봇 하드웨어를 직접 다루나요?",
+      answer: "가능한 경우 온사이트로 테스트하지만, 원격 시뮬레이션·로깅 기반도 지원합니다.",
+    },
+    {
+      question: "에이전트형 AI의 외부 API 호출도 검증하나요?",
+      answer: "네, API·도구 호출 경계조건, Rate Limit(요청 제한), 예외 처리까지 점검합니다.",
+    },
+    {
+      question: "Retest는 어떻게 이루어지나요?",
+      answer: "수정 사항 반영 후 동일/확장 시나리오로 재실행하고 Evidence Pack을 갱신합니다.",
+    },
+    {
+      question: "보고서는 어느 수준까지 제공되나요?",
+      answer: "Scorecard, Heatmap, Failure Path, Fix Guide, Evidence Pack을 포함한 Executive-ready Report를 제공합니다.",
+    },
+    {
+      question: "스타트업 초기 단계도 적합한가요?",
+      answer: "Starter 패키지는 단일 로봇/에이전트와 핵심 시나리오에 집중해 초기 출시 리스크를 줄입니다.",
+    },
+    {
+      question: "테스트 기간은 얼마나 걸리나요?",
+      answer: "패키지에 따라 2~4주이며, 사전 정의된 시나리오 수와 온사이트 여부에 따라 달라집니다.",
+    },
+    {
+      question: "데이터 보안은 어떻게 보장하나요?",
+      answer: "격리된 테스트 환경과 최소 데이터 수집 원칙을 따르며 접근 로그를 공유합니다.",
+    },
+    {
+      question: "커스텀 시나리오를 추가할 수 있나요?",
+      answer: "네. 고위험 산업이나 특정 규제 환경에 맞춰 추가 설계가 가능합니다.",
+    },
+    {
+      question: "정기 Subscription(구독) 형태도 가능한가요?",
+      answer: "Continuous Retest Subscription을 통해 월간/분기 재테스트와 업데이트된 증빙을 제공합니다.",
+    },
+  ],
+};
+
+export const finalCta = {
+  heading: "배포 전, 신뢰를 먼저 확보하세요",
+  subheading: "지금 상담하면 샘플 Evidence Pack(증빙 패키지)과 테스트 시나리오 제안을 함께 드립니다.",
+  primaryCta: "프로젝트 상담",
+  secondaryCta: "리포트 샘플 받기",
+};
+
+export const servicesPage = {
+  hero: {
+    title: "5가지 서비스, 한 번에 비교하고 선택",
+    subtitle:
+      "배포 전 행동 리스크 스트레스 테스트부터 정기 Retest(재테스트) Subscription(구독)까지, 목적별로 묶인 패키지를 제공합니다.",
+    primaryCta: "상담 문의",
+    secondaryCta: "서비스별 상세 보기",
+  },
+  note: "가격은 범위 기준이며, 실제 금액은 시스템 범위와 온사이트 여부에 따라 조정됩니다.",
+  items: [
+    {
+      slug: "ai-red-teaming-core",
+      name: "AI Red Teaming Core",
+      tagline: "Physical AI·Agentic AI 행동 리스크를 증빙 중심으로 검증",
+      priceRange: "700만~1,400만",
+      duration: "3~4주",
+      recommended: "로봇/에이전트 상용 배포 전에 리스크를 선제적으로 발견하고 싶은 팀",
+      deliverables: [
+        "Scorecard(점수표)",
+        "Heatmap(히트맵)",
+        "Failure Path(실패 경로)",
+        "Fix Guide(수정 가이드)",
+        "Evidence Pack(증빙 패키지)",
+      ],
+      includes: [
+        "Adversarial·Integration 시나리오 15~20개 실행",
+        "온사이트 또는 시뮬레이션 기반 테스트",
+        "Retest(재테스트) 1회 포함",
+      ],
+      excludes: [
+        "법률 자문/규제 인증",
+        "물리 하드웨어 수리·패치",
+        "모델 재학습 대행",
+      ],
+    },
+    {
+      slug: "pre-deployment-release-gate",
+      name: "Pre-Deployment Release Gate",
+      tagline: "배포 전 Release Gate(배포 게이트) 기준 정의와 통과 검증",
+      priceRange: "600만~1,200만",
+      duration: "2~3주",
+      recommended: "배포 전 통과 기준을 명확히 하고, 경영진 보고까지 한번에 처리해야 하는 팀",
+      deliverables: [
+        "Release Gate 기준서",
+        "Scorecard(점수표)",
+        "Evidence Pack(증빙 패키지)",
+        "Executive-ready Report(경영진용 리포트) 요약 슬라이드",
+      ],
+      includes: [
+        "Gate 기준 수립 워크숍",
+        "자동화 체크리스트/테스트 스크립트 실행",
+        "경영진 보고용 요약 정리",
+      ],
+      excludes: [
+        "실시간 모니터링 구축",
+        "법적 인증 문서 발급",
+        "장기 운영 컨설팅",
+      ],
+    },
+    {
+      slug: "trust-evidence-pack",
+      name: "Trust Evidence Pack",
+      tagline: "투자자·고객 설득용 Evidence Pack(증빙 패키지) 단일 납품",
+      priceRange: "400만~900만",
+      duration: "1~2주",
+      recommended: "이미 테스트한 결과를 재구성해 신뢰 증빙 자료로 만들고 싶은 팀",
+      deliverables: [
+        "Evidence Pack(증빙 패키지)",
+        "로그·동영상 클립·테스트 스크립트",
+        "요약 리포트",
+      ],
+      includes: [
+        "핵심 시나리오 8~12개 선정 및 실행",
+        "재현 가능한 기록 및 캡처 수집",
+        "보안 검토 메모",
+      ],
+      excludes: [
+        "심층 위협 모델링",
+        "장기 지원/운영",
+        "법적 보장 문구",
+      ],
+    },
+    {
+      slug: "incident-readiness-package",
+      name: "Incident Readiness Package",
+      tagline: "운영 중 사고 대비 런북과 테이블탑 시뮬레이션 포함",
+      priceRange: "500만~1,000만",
+      duration: "1~2주",
+      recommended: "운영 단계에서 사고 대응 프로토콜을 빠르게 갖춰야 하는 팀",
+      deliverables: [
+        "Incident Runbook(대응 런북)",
+        "알림·에스컬레이션 맵",
+        "테이블탑 시뮬레이션 결과",
+        "Evidence Pack 업데이트",
+      ],
+      includes: [
+        "Failure Path(실패 경로) 기반 대응 플로우 설계",
+        "연습 시나리오 5~8개 진행",
+        "포스트모텀 템플릿 제공",
+      ],
+      excludes: [
+        "SOC 구축/24·7 온콜",
+        "법률/규제 대응 대행",
+        "데이터 호스팅",
+      ],
+    },
+    {
+      slug: "continuous-retest-subscription",
+      name: "Continuous Retest Subscription",
+      tagline: "월간/분기 Retest(재테스트)와 증빙 갱신을 묶은 구독",
+      priceRange: "월 250만~450만",
+      duration: "월 단위",
+      recommended: "모델/정책 업데이트가 잦고 지속적 증빙이 필요한 팀",
+      deliverables: [
+        "월간 Retest 리포트",
+        "증빙 업데이트",
+        "추세 Heatmap(히트맵)",
+        "이슈 알림 및 월간 요약 콜",
+      ],
+      includes: [
+        "월/분기 주기 Retest 실행",
+        "시나리오·체크리스트 지속 업데이트",
+        "경영진 요약 콜",
+      ],
+      excludes: [
+        "무제한 테스트",
+        "온사이트 상주",
+        "데이터 호스팅/보관",
+      ],
+    },
+  ],
+};
+
+export const contact = {
+  heading: "Contact",
+  heroTitle: "Risk Snapshot(리스크 스냅샷) 미팅으로 시작하세요",
+  heroSubtitle:
+    "배포 전 행동 리스크를 정리하고 우선순위를 제시합니다. 증빙 가능한 범위부터 짧게 점검하세요.",
+  leadBullets: [
+    "Physical AI·Agentic AI 전용 체크리스트로 바로 스코핑",
+    "Evidence Pack(증빙 패키지) 샘플과 연계 일정 제안",
+    "법률·규제 보장은 없으며, 기술적 행동 검증에 집중",
+  ],
+  concerns: [
+    "Physical AI Safety: 충돌/접촉 위험", 
+    "Agentic AI Goal Misalignment(목표 불일치)",
+    "Tool Misuse(툴 오남용)·권한 남용",
+    "Prompt Injection/Adversarial 공격 노출",
+    "Integration Failure(통합 실패)·API/PLC 경계조건",
+    "Monitoring & Retest Loop 필요",
+  ],
+  privacyNote: "민감정보·개인정보는 제출하지 마세요. 테스트용 더미 데이터나 추상화된 설명만 수집합니다.",
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: Array<string | undefined | false | null>) {
+  return twMerge(clsx(inputs));
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,50 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      boxShadow: {
+        card: "0 10px 40px -20px rgba(15, 23, 42, 0.25)",
+      },
+      fontFamily: {
+        sans: ["Pretendard", "Inter", "system-ui", "-apple-system", "sans-serif"],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a monthly eight-post blog content calendar focused on Physical and Agentic AI red teaming
- include target keywords, search intent, outlines, CTA placement, and lead magnet ideas for each post
- provide shared writing guidelines to keep tone, language, and legal-safe phrasing consistent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402e446eb48330b4da4eb2a24ce7f3)